### PR TITLE
Fix float error

### DIFF
--- a/lib/plug_accept_language.ex
+++ b/lib/plug_accept_language.ex
@@ -39,6 +39,11 @@ defmodule PlugAcceptLanguage do
     [{locale, 1.0} | acc]
   end
 
-  defp to_q(%{"q" => q}), do: String.to_float(q)
+  defp to_q(%{"q" => q}) do
+    case Float.parse(q) do
+      { num, _ } -> num
+      :error -> 1.0
+    end
+  end
   defp to_q(_), do: 1.0
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,8 +8,8 @@ defmodule PlugAcceptLanguage.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     package: package,
-     deps: deps]
+     package: package(),
+     deps: deps()]
   end
 
   def application do
@@ -18,8 +18,8 @@ defmodule PlugAcceptLanguage.Mixfile do
 
   defp deps do
     [{ :plug, "~> 1.0.2", only: [:dev, :test] },
-     { :excheck, "~> 0.2.3", only: [:dev, :test] },
-     { :triq, github: "krestenkrab/triq", only: [:dev, :test] },]
+     { :excheck, "~> 0.5.3", only: [:dev, :test] },
+     { :triq, github: "triqng/triq", only: [:dev, :test] },]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"excheck": {:hex, :excheck, "0.2.3"},
-  "plug": {:hex, :plug, "1.0.2"},
-  "triq": {:git, "git://github.com/krestenkrab/triq.git", "c7306b8eaea133d52140cb828817efb5e50a3d52", []}}
+%{"excheck": {:hex, :excheck, "0.5.3", "7326a29cc5fdb6900e66dac205a6a70cc994e2fe037d39136817d7dab13cdabf", [:mix], []},
+  "plug": {:hex, :plug, "1.0.2", "cc341ac229c88fc6b04d1771f62f675640f24cea97a6313a49ffcaa8236e949e", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
+  "triq": {:git, "https://github.com/triqng/triq.git", "2c497398e020e06db8496f1d89f12481cc5adab9", []}}

--- a/test/plug_accept_language_test.exs
+++ b/test/plug_accept_language_test.exs
@@ -5,12 +5,12 @@ defmodule PlugAcceptLanguage.Test do
 
   def smaller(domain, factor \\ 2) do
     sized fn(size) ->
-      resize(:random.uniform((div(size, factor))+1), domain)
+      resize(:rand.uniform((div(size, factor))+1), domain)
     end
   end
 
   defp dec do
-    bind real, fn(value) ->
+    bind real(), fn(value) ->
       abs(value - trunc(value)) |> to_string
     end
   end
@@ -34,19 +34,19 @@ defmodule PlugAcceptLanguage.Test do
   end
 
   defp string do
-    bind unicode_binary, &String.replace(&1, ",", "")
+    bind unicode_binary(), &String.replace(&1, ",", "")
   end
 
   defp param do
     oneof([
-      ["q", dec],
-      [string, string]
+      ["q", dec()],
+      [string(), string()]
     ])
   end
 
   defp params do
     oneof [
-      bind(smaller(list(param), 2), &Enum.join(&1, ";")),
+      bind(smaller(list(param()), 2), &Enum.join(&1, ";")),
       ""
     ]
   end
@@ -58,7 +58,7 @@ defmodule PlugAcceptLanguage.Test do
   end
 
   defp header do
-    bind {ws, locale, ws, ws, params, ws}, fn
+    bind {ws(), locale(), ws(), ws(), params(), ws()}, fn
       ({w1, l, w2, _, "", _}) ->
         [w1,l,w2,"","","",""]
       ({w1, l, w2, w3, p, w4}) ->
@@ -67,12 +67,12 @@ defmodule PlugAcceptLanguage.Test do
   end
 
   defp accepts do
-    smaller(list(header), 2)
+    smaller(list(header()), 2)
   end
 
   @tag timeout: :infinity
   property :plug_x_forwarded_for do
-    for_all hs in list(accepts) do
+    for_all hs in list(accepts()) do
       conn = Enum.reduce(hs, conn(:get, "/"), fn(header, conn = %{req_headers: headers}) ->
         %{conn | req_headers: headers ++ [{"accept-language", Enum.join(header,",")}]}
       end)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+ExCheck.start()
 ExUnit.start()


### PR DESCRIPTION
Hi,
I'm using your code in production, but ran into an issue 
```
** (exit) an exception was raised:
    ** (ArgumentError) argument error
        :erlang.binary_to_float("1")
        (plug_accept_language) lib/plug_accept_language.ex:42: PlugAcceptLanguage.to_q/1
        (plug_accept_language) lib/plug_accept_language.ex:30: PlugAcceptLanguage.parse_language/2
        (elixir) lib/enum.ex:1755: Enum."-reduce/3-lists^foldl/2-0-"/3
        (plug_accept_language) lib/plug_accept_language.ex:16: PlugAcceptLanguage.parse_header/2
        (plug_accept_language) lib/plug_accept_language.ex:5: PlugAcceptLanguage.list/1
        (ui) lib/ui/plugs/get_locale.ex:16: Ui.GetLocale.find_locale/1
        (ui) lib/ui/plugs/get_locale.ex:7: Ui.GetLocale.call/2
```

The cause of this error is that String.to_float\1 does not accept integer value strings, it needs valid floats.  I replaced the String.to_float\1 with Float.parse\1.

I would have liked to add specific test for  this case, but cannot understand where to add it, as it is the tests run fine with this change.

I also updated the code to be compatible with recent Erlang/Elixir versions.
